### PR TITLE
[CA-641] Update NR PHP Agent to v8.1.0.209

### DIFF
--- a/8.1.0.209/Dockerfile
+++ b/8.1.0.209/Dockerfile
@@ -1,0 +1,17 @@
+FROM alpine:3.6
+
+ENV NR_PORT /tmp/.newrelic.sock
+
+ARG NR_VERSION=8.1.0.209
+ENV NR_FILE_NAME=newrelic-php5-$NR_VERSION-linux-musl
+ENV NR_FILE_URL=https://download.newrelic.com/php_agent/archive/$NR_VERSION/$NR_FILE_NAME.tar.gz
+
+RUN set -ex; \
+    apk --no-cache add curl; \
+    curl --connect-timeout 10 -o nr.tar.gz -fSL $NR_FILE_URL; \
+    tar -xf nr.tar.gz; \
+    cp $NR_FILE_NAME/daemon/newrelic-daemon.x64 /usr/local/bin/newrelic-daemon; \
+    mkdir -p /var/log/newrelic; \
+    rm -rf newrelic-php5* nr.tar.gz;
+
+CMD ["sh", "-c", "/usr/local/bin/newrelic-daemon -f --port ${NR_PORT}"]

--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ These images are tied to specific [New Relic daemon releases](https://download.n
 ## Running
 The following command runs the New Relic daemon and exposes the service on port 8004. `NR_PORT` can also contain a socket name that could be shared between containers.
 ```
-docker run -d -e NR_PORT=8004 -p 8004:8004 wpengine/newrelic-php-daemon:7.6.0.201
+docker run -d -e NR_PORT=8004 -p 8004:8004 wpengine/newrelic-php-daemon:8.1.0.209
 ```
 
 ## Building
 ```
-docker build -t wpengine/newrelic-php-daemon:$VERSION 7.6.0.201
+docker build -t wpengine/newrelic-php-daemon:$VERSION 8.1.0.209
 ```


### PR DESCRIPTION
Newer versions of the New Relic PHP extension do not provide the collector hostname when talking with the agent, yet the older agent expects this to be provided, causing errors when any Gophprized sites try to send metrics to NR.

This PR adds the latest version of the agent so we can fix the incompatibility with the newer extension.